### PR TITLE
Only show next steps after user answered question about existing config

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,33 +64,33 @@
       <div ng-if="!isOnline()" class="wizard-category">
         <ng-include src="'shared/offlineWarning/offlineWarning.html'"></ng-include>
       </div>
-      <div class="wizard-category">
-      <ng-include src="'shared/loadConfig/loadConfig.html'"></ng-include>
+      <div class="wizard-category" ng-hide='pastConfigurationRestore'>
+        <ng-include src="'shared/loadConfig/loadConfig.html'"></ng-include>
       </div>
-        <div class="wizard-category">
-          <ng-include src="'shared/basicRouterSetup/basicRouterSetup.html'"></ng-include>
-        </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
+        <ng-include src="'shared/basicRouterSetup/basicRouterSetup.html'"></ng-include>
+      </div>
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/contactDetails/contactDetails.html'"></ng-include>
       </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/routerLocation/routerLocation.html'"></ng-include>
       </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/internetSharing/internetSharing.html'"></ng-include>
       </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/ipAddresses/ipAddresses.html'"></ng-include>
       </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/monitoring/monitoring.html'"></ng-include>
       </div>
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <ng-include src="'shared/advancedWifi/advancedWifi.html'"></ng-include>
       </div>
 
       <!-- submission -->
-      <div class="wizard-category">
+      <div class="wizard-category" ng-show="pastConfigurationRestore">
         <div class="container text-right">
           <span class="text-danger" translate
               ng-if="wizardForm.$submitted && wizardForm.$invalid">

--- a/src/js/controllers/wizard.js
+++ b/src/js/controllers/wizard.js
@@ -19,8 +19,22 @@ module.exports = function(app) {
         $scope.upload($scope.files);
       }, true);
       $scope.log = '';
+      $scope.pastConfigurationRestore = false;
+      $scope.hasConfiguration = false;
+
+
+      $scope.showConfigRestore = function(){
+        $scope.hasConfiguration = true;
+      }
+
+      $scope.skipAhead = function(){
+        $scope.pastConfigurationRestore = true;
+      }
 
       $scope.upload = function(files) {
+        if (!files){
+          return;
+        }
         var reader = new FileReader();
         reader.onload = function() {
           var myWizard = JSON.parse(reader.result);
@@ -35,6 +49,7 @@ module.exports = function(app) {
             }
           }
         }
+        $scope.pastConfigurationRestore = true;
       };
 
       $scope.wizard = {

--- a/src/js/controllers/wizard.js
+++ b/src/js/controllers/wizard.js
@@ -18,21 +18,20 @@ module.exports = function(app) {
       $scope.$watch('files', function() {
         $scope.upload($scope.files);
       }, true);
+
       $scope.log = '';
       $scope.pastConfigurationRestore = false;
       $scope.hasConfiguration = false;
-
-
-      $scope.showConfigRestore = function(){
+      $scope.showConfigRestore = function() {
         $scope.hasConfiguration = true;
-      }
+      };
 
-      $scope.skipAhead = function(){
+      $scope.skipAhead = function() {
         $scope.pastConfigurationRestore = true;
-      }
+      };
 
       $scope.upload = function(files) {
-        if (!files){
+        if (!files) {
           return;
         }
         var reader = new FileReader();

--- a/src/nls/locale-en.json
+++ b/src/nls/locale-en.json
@@ -7,6 +7,8 @@
   },
   "loadconfig": {
     "headline": "Load configuration",
+		"hasconfiguration": "I have an exisiting config file",
+		"hasnoconfiguration": "I want to start fresh",
     "help": "If you already have a config file, you can load it. So you're able to update it or adapt it for other routers you want to set up.",
     "upload": {
       "label": "Your file",

--- a/src/shared/loadConfig/loadConfig.html
+++ b/src/shared/loadConfig/loadConfig.html
@@ -10,8 +10,13 @@
     <p>
       <span translate>.help</span>
     </p>
+    <div>
+      <a class="btn btn-info" ng-click='skipAhead()' translate>.hasnoconfiguration</a>
+      <a class="btn btn-info" ng-click='showConfigRestore()' translate>.hasconfiguration</a>
+    </div>
     <div class="form-group has-feedback"
-         translate-namespace=".upload">
+         translate-namespace=".upload"
+         ng-show='hasConfiguration'>
       <label class="col-md-3 control-label" translate>
         .label
       </label>


### PR DESCRIPTION
Now, the users have to select if they have an existing config or not.
If they do the form to upload it will be shown and then the rest of the 
wizard will be filled in already. If not, they will just see an empty wizard.

It would be nicer to wrap all the steps in a `div` and set the `ng-show` on it but that seems to break the layout...

Generally I am not to happy with the code and looking forward to alternative approaches!
